### PR TITLE
Updated the namespace of ApiCache

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ protected $middlewareGroups = [
     'api' => [
         'throttle:60,1',
         'bindings',
-        Streams\Api\Http\Middleware\ApiCache::class,
+        \Streams\Api\Http\Middleware\ApiCache::class,
     ],
 ];
 ```


### PR DESCRIPTION
Streams is a global namespace and not a local.